### PR TITLE
Environment variables for GitHub token in config

### DIFF
--- a/src/.idea/.idea.GitHubReleaser/.idea/.gitignore
+++ b/src/.idea/.idea.GitHubReleaser/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/projectSettingsUpdater.xml
+/.idea.GitHubReleaser.iml
+/modules.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/src/.idea/.idea.GitHubReleaser/.idea/encodings.xml
+++ b/src/.idea/.idea.GitHubReleaser/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/src/.idea/.idea.GitHubReleaser/.idea/indexLayout.xml
+++ b/src/.idea/.idea.GitHubReleaser/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/src/.idea/.idea.GitHubReleaser/.idea/vcs.xml
+++ b/src/.idea/.idea.GitHubReleaser/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/src/GitHubReleaser/GitHubReleaser.csproj
+++ b/src/GitHubReleaser/GitHubReleaser.csproj
@@ -3,10 +3,10 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
-    <Version>1.0.1.101</Version>
+    <Version>1.0.0.0</Version>
     <LangVersion>latest</LangVersion>
-    <AssemblyVersion>1.0.1.103</AssemblyVersion>
-    <FileVersion>1.0.1.103</FileVersion>
+    <AssemblyVersion>1.0.3.104</AssemblyVersion>
+    <FileVersion>1.0.3.104</FileVersion>
   </PropertyGroup>  
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>pdbonly</DebugType>

--- a/src/GitHubReleaser/Model/CommandLineParameters.cs
+++ b/src/GitHubReleaser/Model/CommandLineParameters.cs
@@ -69,10 +69,7 @@ namespace GitHubReleaser.Model
       }
 
       commandLineArguments.Result = result;
-
-#if DEBUG
-      commandLineArguments.GitHubToken = Secrets.GitHubToken;
-#endif
+      
       return commandLineArguments;
     }
 
@@ -144,7 +141,7 @@ namespace GitHubReleaser.Model
       IsDraft = settings.IsDraft;
       DeleteFilesAfterUpload = settings.DeleteFilesAfterUpload;
       FileForVersion = settings.FileForVersion;
-      GitHubToken = settings.GitHubToken;
+      GitHubToken = Environment.ExpandEnvironmentVariables(settings.GitHubToken);
       GitHubRepo = settings.GitHubRepo;
     }
 


### PR DESCRIPTION
The GitHub token handling was modified. Instead of the previous implementation where the token was directly derived from config file, it now supports extraction from environment variables. This change is implemented in order to provide additional security and avoid storing sensitive data such as tokens directly into the config file.